### PR TITLE
Prepare for Ruby 2.4

### DIFF
--- a/lib/druid/query.rb
+++ b/lib/druid/query.rb
@@ -270,8 +270,8 @@ module Druid
     end
 
     def mk_interval(from, to)
-      from = today + from if from.is_a?(Fixnum)
-      to = today + to if to.is_a?(Fixnum)
+      from = today + from if from.is_a?(Integer)
+      to = today + to if to.is_a?(Integer)
 
       from = DateTime.parse(from.to_s) unless from.respond_to? :iso8601
       to = DateTime.parse(to.to_s) unless to.respond_to? :iso8601

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -212,6 +212,13 @@ describe Druid::Query do
     JSON.parse(@query.to_json)['intervals'].should == ["#{a.iso8601}/#{b.iso8601}"]
   end
 
+  it 'treat integers as relative to today' do
+    a = Time.now.to_date.to_time
+    b = Time.now.to_date.to_time + 1
+    @query.interval(0, 1)
+    JSON.parse(@query.to_json)['intervals'].should == ["#{a.iso8601}/#{b.iso8601}"]
+  end
+
   it 'takes a granularity from string' do
     @query.granularity('all')
     JSON.parse(@query.to_json)['granularity'].should == 'all'


### PR DESCRIPTION
Use Integer instead of Fixnum since it has been deprecated as of Ruby 2.4.

Tests pass:
```
$ rake

Druid::Client
  calls zookeeper on intialize
  creates a query
  sends query if block is given
  parses response on 200
  raises on request failure
  should have a static setup
  should report dimensions of a data source correctly
  should report metrics of a data source correctly

Druid::Query
  takes a datasource in the constructor
  takes a query type
  sets query type by group_by
  sets query type to timeseries
  takes dimensions from group_by method
  takes dimension, metric and threshold from topn method
  builds aggregations on long_sum
  appends long_sum properties from aggregations on calling long_sum again
  removes duplicate aggregation fields
  must be chainable
  parses intervals from strings
  takes multiple intervals
  accepts Time objects for intervals
  treat integers as relative to today
  takes a granularity from string
  should take a period
  creates a in_circ filter
  creates a in_rec filter
  creates an equals filter
  creates an equals filter with ==
  creates a not filter
  creates a not filter with neq
  creates a not filter with !=
  creates an and filter
  creates an or filter
  chains filters
  creates filter from hash
  creates an in statement with or filter
  creates a nin statement with and filter
  creates a javascript with > filter
  creates a mixed javascript filter
  creates a complex javascript filter
  can chain two in statements
  does not accept in with empty array
  does raise on invalid filter statement
  raises if no value is passed to a filter operator
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<ArgumentError: wrong number of arguments (given 0, expected 1)>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/michwatt/workspace/TetrationAnalytics/ruby-druid/spec/lib/query_spec.rb:431:in `block (2 levels) in <top (required)>'.
  raises wrong number of arguments if  filter operator is called without param
  should query regexp using .regexp(string)
  should query regexp using .eq(regexp)
  should query regexp using .in([regexp])
  takes type, limit and columns from limit method
  #postagg
    build a post aggregation with a constant right
    build a + post aggregation
    build a - post aggregation
    build a * post aggregation
    build a / post aggregation
    build a complex post aggregation
    adds fields required by the postagg operation to longsum
    chains aggregations
    builds a javascript post aggregation
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<RuntimeError: Invalid Javascript function>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/michwatt/workspace/TetrationAnalytics/ruby-druid/spec/lib/query_spec.rb:143:in `block (3 levels) in <top (required)>'.
    raises an error when an invalid javascript function is used
  #having
    creates a greater than having clause
    chains having clauses with and

Druid::ZooHandler
  reports services and data sources correctly

Deprecation Warnings:

Using `should_receive` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/michwatt/workspace/TetrationAnalytics/ruby-druid/spec/lib/client_spec.rb:4:in `block (2 levels) in <top (required)>'.

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /Users/michwatt/workspace/TetrationAnalytics/ruby-druid/spec/lib/client_spec.rb:10:in `block (2 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

2 deprecation warnings total

Finished in 0.03625 seconds (files took 0.82304 seconds to load)
62 examples, 0 failures
```