### PR TITLE
Client#send - pass query to broker_uri which is needed by H4Druid::Client#broker_uri

### DIFF
--- a/lib/druid/client.rb
+++ b/lib/druid/client.rb
@@ -10,7 +10,7 @@ module Druid
     end
 
     def send(query)
-      uri = broker_uri
+      uri = broker_uri(query)
 
       req = Net::HTTP::Post.new(uri.path, {'Content-Type' =>'application/json'})
       req.body = query.to_json
@@ -53,7 +53,8 @@ module Druid
       end
     end
 
-    def broker_uri
+    # H4Druid::Client#broker_uri needs query to be passed to it.
+    def broker_uri(_query = nil)
       URI(@broker_url) if @broker_url
     rescue
       nil

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -33,6 +33,21 @@ describe Druid::Client do
     client.send(client.query('test/test').interval("2013-04-04", "2013-04-04"))
   end
 
+  it 'passes query to broker_uri' do
+    stub_request(:post, 'http://www.example.com/druid/v2')
+      .with(body: '{"dataSource":"test","granularity":"all","intervals":["2013-04-04T00:00:00+00:00/2013-04-04T00:00:00+00:00"]}',
+            headers: { 'Accept' => '*/*', 'Content-Type' => 'application/json', 'User-Agent' => 'Ruby' })
+      .to_return(status: 200, body: '[]', headers: {})
+
+    client = Druid::Client.new('http://www.example.com/druid/v2')
+    query = client.query('test/test').interval('2013-04-04', '2013-04-04')
+
+    JSON.should_receive(:parse).and_return([])
+    client.should_receive(:broker_uri).with(query).and_call_original
+
+    client.send(query)
+  end
+
   it 'raises on request failure' do
     stub_request(:post, "http://www.example.com/druid/v2").
       with(:body => "{\"dataSource\":\"test\",\"granularity\":\"all\",\"intervals\":[\"2013-04-04T00:00:00+00:00/2013-04-04T00:00:00+00:00\"]}",


### PR DESCRIPTION
# Summary
Our sub-class of `Druid::Client` needs to have `query` passed to `broker_uri` in order to modify the `broker_uri` to point to the new DFE (`/druid/v2` will become `/ui/druid/v2/<root_app_scope_id>`). Since we call `super` in our `H4Druid::Client#send` method, we need to update `Druid::Client#send` to pass query to `broker_uri`.

# Reviewers
@mikwat 