### PR TITLE
Remove zk gem dependency since it's no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,11 @@ ruby-druid features a [Squeel](https://github.com/ernie/squeel)-like query DSL
 and generates a JSON query that can be sent to druid directly. A console for
 testing is also provided.
 
-[![Gem Version](https://badge.fury.io/rb/ruby-druid.png)](http://badge.fury.io/rb/ruby-druid)
-[![Build Status](https://travis-ci.org/liquidm/ruby-druid.png)](https://travis-ci.org/liquidm/ruby-druid)
-[![Code Climate](https://codeclimate.com/github/liquidm/ruby-druid.png)](https://codeclimate.com/github/liquidm/ruby-druid)
-[![Dependency Status](https://gemnasium.com/liquidm/ruby-druid.png)](https://gemnasium.com/liquidm/ruby-druid)
-
 ## Installation
 
 Add this line to your application's Gemfile:
 
-    gem 'ruby-druid'
+    gem 'h4-ruby-druid'
 
 And then execute:
 
@@ -23,12 +18,12 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install ruby-druid
+    $ gem install h4-ruby-druid
 
 ## Usage
 
 ```ruby
-Druid::Client.new('zk1:2181,zk2:2181/druid').query('service/source')
+Druid::Client.new('http://www.example.com/druid/v2').query('service/source')
 ```
 
 returns a query object on which all other methods can be called to create a
@@ -37,7 +32,7 @@ full and valid druid query.
 A query object can be sent like this:
 
 ```ruby
-client = Druid::Client.new('zk1:2181,zk2:2181/druid')
+client = Druid::Client.new('http://www.example.com/druid/v2')
 query = Druid::Query.new('service/source')
 client.send(query)
 ```
@@ -51,11 +46,10 @@ each row.  The timestamp by can be received by a method with the same name
 An options hash can be passed when creating `Druid::Client` instance:
 
 ```ruby
-client = Druid::Client.new('zk1:2181,zk2:2181/druid', http_timeout: 20)
+client = Druid::Client.new('http://www.example.com/druid/v2', http_timeout: 20)
 ```
 
 Supported options are:
-* `static_setup` to explicitly specify a broker url, e.g. `static_setup: { 'my/source_name' => 'http://1.2.3.4:8080/druid/v2/' }`
 * `http_timeout` to define a timeout for sending http queries to a broker (in minutes, default value is 2)
 
 ### GroupBy

--- a/bin/dripl
+++ b/bin/dripl
@@ -3,13 +3,8 @@
 require 'bundler/setup'
 require 'liquid/boot'
 
-def zookeeper(value)
-  @zk_uri = value
-end
-
 def uri(value)
-  puts "using 'uri' in the config is deprecated, use 'zookeeper' instead"
-  zookeeper value
+  @uri = value
 end
 
 def source(value)
@@ -21,18 +16,18 @@ def options(value)
 end
 
 begin
-  driplrc = File.read(File.join(File.expand_path("../..", __FILE__), '.driplrc'))
+  driplrc = File.read(File.join(File.expand_path('..', __dir__), '.driplrc'))
 rescue
-  puts "You need to create a .driplrc, take a look at dot_driplrc_example"
+  puts 'You need to create a .driplrc, take a look at dot_driplrc_example'
   exit 1
 end
 
 instance_eval(driplrc)
 
-unless @zk_uri || (@options && @options[:static_setup])
-  puts "Your .driplrc is incomplete, please fix"
+unless @uri
+  puts 'Your .driplrc is incomplete, please fix'
   exit 1
 end
 
 require 'druid/console'
-Druid::Console.new(@zk_uri, @source, @options)
+Druid::Console.new(@uri, @source, @options)

--- a/dot_driplrc_example
+++ b/dot_driplrc_example
@@ -1,12 +1,3 @@
-## your zookeeper config. For static scenarios (i.e. ssh tunnels) see options
-##
-# zookeeper "localhost:2181/druid"
-
-## using options, you can disable zookeeper lookup
-## options[:static_setup], the key is the source name, the value is the brokers post uri
-##
-# options :static_setup => { 'example/events' => 'http://localhost:8080/druid/v2/' }
-
 ## dripl will default to use the first available data source. use this to override
 ##
 # source "example/events"

--- a/ruby-druid.gemspec
+++ b/ruby-druid.gemspec
@@ -15,6 +15,5 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "zk"
   spec.add_dependency "rest-client"
 end


### PR DESCRIPTION
@visthakk is having trouble installing this gem on Ubuntu 19.04 due to problems with zookeeper. I realized this gem no longer depends on zk, so removing it from the gemspec.

Also updated the readme a bit.

CC: @ali-tetration 